### PR TITLE
Update Portal build to be able to build from any branch

### DIFF
--- a/.github/workflows/portal-build.yaml
+++ b/.github/workflows/portal-build.yaml
@@ -12,7 +12,7 @@ env:
   OPENSHIFT_NAMESPACE: ${{ secrets.OPENSHIFT_NAMESPACE }}
   BUILD_CONFIG_APP: angular-app-build
   BUILD_CONFIG_NGINX: angular-on-nginx-build
-
+  REF: ${{ github.ref }} # This is the branch or tag ref that triggered the workflow
 jobs:
 
   openshift-build:
@@ -27,7 +27,7 @@ jobs:
           parameters: '{"apitoken": "${{ secrets.OPENSHIFT_TOKEN }}", "acceptUntrustedCerts": "true"}'
           cmd: |
             'version'
-            'start-build ${BUILD_CONFIG_APP} -n ${OPENSHIFT_NAMESPACE} --follow'
+            'start-build ${BUILD_CONFIG_APP} -n ${OPENSHIFT_NAMESPACE} --commit ${REF}  --follow'
 
       - name: Build NGinx Runtime Container
         uses: redhat-developer/openshift-actions@v1.1
@@ -37,4 +37,4 @@ jobs:
           parameters: '{"apitoken": "${{ secrets.OPENSHIFT_TOKEN }}", "acceptUntrustedCerts": "true"}'
           cmd: |
             'version'
-            'start-build ${BUILD_CONFIG_NGINX} -n ${OPENSHIFT_NAMESPACE} --follow'
+            'start-build ${BUILD_CONFIG_NGINX} -n ${OPENSHIFT_NAMESPACE} --commit ${REF} --follow'

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -1,0 +1,19 @@
+# CICD
+
+The application is managed via Github Actions.
+
+| GitHub Action    | Builds/Deploys From         | Description                                                                                     |
+|------------------|------------------------------|-------------------------------------------------------------------------------------------------|
+| `api-build`      | `master`                     | Builds the API; always uses the `master` branch.                                                |
+| `api-deploy`     | `master`                     | Deploys the API; only deploys builds from the `master` branch.                                  |
+| `portal-build`   | Current workflow branch      | Chain build that builds the Angular app and packages it into an Nginx image, deployed to `dev`. |
+| `portal-deploy`  | `master`                     | Deploys the Portal; only deploys builds originating from `master`.                              |
+
+
+This application has no defined deployment strategy. Because it is in maintenance mode, a suggested pattern is as follows:
+
+1. Checkout your feature/bugfix branch from master
+2. Make and test your changes
+3. Deploy your branch (if portal) and test in OCP dev environment
+4. Merge your PR (this kicks of builds/and deploys for master branch)
+5. Run deploy workflows to deploy to higher environments (test and prod)

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -7,7 +7,7 @@ The application is managed via Github Actions.
 | `api-build`      | `master`                     | Builds the API; always uses the `master` branch.                                                |
 | `api-deploy`     | `master`                     | Deploys the API; only deploys builds from the `master` branch.                                  |
 | `portal-build`   | Current workflow branch      | Chain build that builds the Angular app and packages it into an Nginx image, deployed to `dev`. |
-| `portal-deploy`  | `master`                     | Deploys the Portal; only deploys builds originating from `master`.                              |
+| `portal-deploy`  | `latest built image`                     | Deploys the Portal; If deploying for test, it deploys the latest image, if deploying for prod it deploys from test.                              |
 
 
 This application has no defined deployment strategy. Because it is in maintenance mode, a suggested pattern is as follows:


### PR DESCRIPTION
The portal build workflow while could be run from any branch was only building from master. This leads to a false positive when testing changes from a PR. 

This change enables performing integration checks in the dev environment prior to merging code to master. 