### PR TITLE
fix(AMOS-8323): prevent blank form submissions reaching Salesforce

### DIFF
--- a/fpo-api/api/survey.py
+++ b/fpo-api/api/survey.py
@@ -45,6 +45,10 @@ class SurveySubmission(APIView):
         if not body:
             return HttpResponseBadRequest("Missing application results")
 
+        complainant = body.get("complainant") or body.get("partyInfo") or body.get("representative") or {}
+        if not complainant.get("Legal Name - Last Name"):
+            return HttpResponseBadRequest("Missing required complainant information")
+
         print("body: ",body)
 
         sSFDC_org = 'qa'

--- a/fpo-web/src/app/hrt-group-review-page/hrt-group-review-page.component.ts
+++ b/fpo-web/src/app/hrt-group-review-page/hrt-group-review-page.component.ts
@@ -226,6 +226,10 @@ export class HrtGroupReviewPageComponent implements OnInit, OnDestroy {
   }
   handleSubmit() {
     if (this.checkbox) {
+      if (!this.formData?.representative?.["Individual Legal Name – Last name"]) {
+        window.alert("Your form data could not be loaded. Please go back to the beginning of the form and try again.");
+        return;
+      }
       console.log("Happy!");
 
       const attachment_html = document.getElementById("pdf-container")

--- a/fpo-web/src/app/hrt-group-review-page/hrt-group-review-page.component.ts
+++ b/fpo-web/src/app/hrt-group-review-page/hrt-group-review-page.component.ts
@@ -226,7 +226,7 @@ export class HrtGroupReviewPageComponent implements OnInit, OnDestroy {
   }
   handleSubmit() {
     if (this.checkbox) {
-      if (!this.formData?.representative?.["Individual Legal Name – Last name"]) {
+      if (!(this.formData && this.formData.representative && this.formData.representative["Individual Legal Name \u2013 Last name"])) {
         window.alert("Your form data could not be loaded. Please go back to the beginning of the form and try again.");
         return;
       }

--- a/fpo-web/src/app/hrt-retaliation-review-page/hrt-retaliation-review-page.component.ts
+++ b/fpo-web/src/app/hrt-retaliation-review-page/hrt-retaliation-review-page.component.ts
@@ -284,7 +284,7 @@ export class HrtRetaliationReviewPageComponent implements OnInit, OnDestroy {
   }
   handleSubmit() {
     if (this.checkbox) {
-      if (!this.formData?.partyInfo?.["Legal Name - Last Name"]) {
+      if (!(this.formData && this.formData.partyInfo && this.formData.partyInfo["Legal Name - Last Name"])) {
         window.alert("Your form data could not be loaded. Please go back to the beginning of the form and try again.");
         return;
       }

--- a/fpo-web/src/app/hrt-retaliation-review-page/hrt-retaliation-review-page.component.ts
+++ b/fpo-web/src/app/hrt-retaliation-review-page/hrt-retaliation-review-page.component.ts
@@ -284,6 +284,10 @@ export class HrtRetaliationReviewPageComponent implements OnInit, OnDestroy {
   }
   handleSubmit() {
     if (this.checkbox) {
+      if (!this.formData?.partyInfo?.["Legal Name - Last Name"]) {
+        window.alert("Your form data could not be loaded. Please go back to the beginning of the form and try again.");
+        return;
+      }
       console.log("Happy!");
 
       const attachment_html = document.getElementById("pdf-container")

--- a/fpo-web/src/app/hrt-review-page/hrt-review-page.component.ts
+++ b/fpo-web/src/app/hrt-review-page/hrt-review-page.component.ts
@@ -145,6 +145,10 @@ export class HrtReviewPageComponent implements OnInit, OnDestroy {
   }
   handleSubmit() {
     if (this.checkbox) {
+      if (!this.formData?.complainant?.["Legal Name - Last Name"]) {
+        window.alert("Your form data could not be loaded. Please go back to the beginning of the form and try again.");
+        return;
+      }
       console.log("Happy!");
       const attachment_html = document.getElementById("pdf-container")
         .innerHTML;

--- a/fpo-web/src/app/hrt-review-page/hrt-review-page.component.ts
+++ b/fpo-web/src/app/hrt-review-page/hrt-review-page.component.ts
@@ -145,7 +145,7 @@ export class HrtReviewPageComponent implements OnInit, OnDestroy {
   }
   handleSubmit() {
     if (this.checkbox) {
-      if (!this.formData?.complainant?.["Legal Name - Last Name"]) {
+      if (!(this.formData && this.formData.complainant && this.formData.complainant["Legal Name - Last Name"])) {
         window.alert("Your form data could not be loaded. Please go back to the beginning of the form and try again.");
         return;
       }


### PR DESCRIPTION
Adds two layers of validation to stop empty payloads created by the
Angular race condition (page refresh on review page) from creating
blank cases in Salesforce.